### PR TITLE
rest: disable USB power save for fatclients and thinclients

### DIFF
--- a/rest/resources/hosts.rb
+++ b/rest/resources/hosts.rb
@@ -52,12 +52,19 @@ class Host < LdapModel
 
   def grub_kernel_arguments
     if ["unregistered", "laptop"].include?(grub_type)
-      ""
-    elsif get_original(:kernel_arguments)
-      kernel_arguments
-    else
-      "quiet splash"
+      return ""
     end
+
+    retval = "quiet splash"
+    if get_original(:kernel_arguments)
+      retval = kernel_arguments
+    end
+
+    if ["thinclient", "fatclient"].include?(grub_type)
+      retval += " usbcore.autosuspend=-1"
+    end
+
+    return retval
   end
 
   def grub_boot_configuration

--- a/rest/test/boot_configuration_test.rb
+++ b/rest/test/boot_configuration_test.rb
@@ -50,7 +50,7 @@ label ltsp-NBD
   menu label LTSP, using NBD
   menu default
   kernel ltsp/schoolprefimage/vmlinuz
-  append ro initrd=ltsp/schoolprefimage/initrd.img init=/sbin/init-puavo puavo.hosttype=thinclient root=/dev/nbd0 nbdroot=:schoolprefimage ACPI
+  append ro initrd=ltsp/schoolprefimage/initrd.img init=/sbin/init-puavo puavo.hosttype=thinclient root=/dev/nbd0 nbdroot=:schoolprefimage ACPI usbcore.autosuspend=-1
   ipappend 2
 EOF
       assert_equal configuration, @data


### PR DESCRIPTION
USB autosuspend might be causing some trouble with various smartboards
and WLAN accesspoints. This commit forces thinclients and fatclients to
disable USB autosuspend for all USB devices. It is not something we like
to have with laptops though.
