### PR TITLE
Update locales

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -343,7 +343,7 @@ en:
 
     servers:
       available_images: "Available images"
-      schools: "School limits?"
+      schools: "School restrictions?"
 
   puavoconf_table:
     show:
@@ -438,7 +438,7 @@ en:
         model: "Devices: Model"
         serial_number: "Devices: Serial number"
 
-    school_limit_title: "School limit:"
+    school_limit_title: "School restriction:"
     school_limit_all: "(All schools)"
 
     more_settings:
@@ -466,7 +466,7 @@ en:
       invalid_search_data: "Invalid search parameters: missing search terms or search terms type"
       search_terms_cleanup_failed: "Search term cleanup failed"
       no_search_terms: "No search terms"
-      school_limit_failed: "School limit parsing failed"
+      school_limit_failed: "School restriction parsing failed"
       invalid_regexp: "Invalid regexp "
       unknown_search_term_type: "Unknown search term type "
 
@@ -764,7 +764,7 @@ en:
       automounts: Automounts
       no_automounts: "(No automounts)"
     school_limit:
-      title: School limit
+      title: School restriction
       boot_description: "Schools that this boot server will serve:"
       ltsp_description: "This LTSP server will only serve these schools:"
       ltsp_description_edit: If none is selected it will serve all schools in the organisation.

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -339,7 +339,7 @@ fi:
       reset_pin: "Nollaus-PIN"
       reset_time: "Nollauspyyntö tehty"
       reset_fulfilled: "Nollauspyyntö täytetty"
-      uptime: "Uptime"
+      uptime: "Käynnissäoloaika"
 
     servers:
       available_images: "Tarjolla olevat kuvatiedostot"
@@ -403,7 +403,7 @@ fi:
         laptop: "Kannettava"
         fatclient: "Verkkopääte"
         printer: "Tulostin"
-        bootserver: "Bootserver"
+        bootserver: "Boot-palvelin"
         other: "(Kaikki muut)"
 
     term_names:
@@ -824,7 +824,7 @@ fi:
   # Printer permissions (accessed through school devices)
   printer_permissions:
     no_printers_html: "Tällä koululla ei ole tulostimia. Pääkäyttäjänä voit lisätä koululle %{href}."
-    bootserver_ref: "boottipalvelimia"
+    bootserver_ref: "boot-palvelimia"
     no_printers_nonowner: "Tälle koululle ei ole määritetty tulostimia boot-palvelimien kautta. Ylläpitäjät, joilla on organisaatiotason omistajaoikeudet, voivat lisätä tulostimia."
     index:
       edit_permissions: Muokkaa oikeuksia...
@@ -1728,7 +1728,7 @@ fi:
       title: "Laitteelle kirjautumiset"
       last_login: "Viimeisin kirjautuja: %{username}, %{at}."
     uptime:
-      title: "Uptime"
+      title: "Käynnissäoloaika"
 
   # Username lists for mass password resets (created by mass imports)
   lists:


### PR DESCRIPTION
English:
"School limit" --> "School restriction".
I think "limit" is not correct for this, while "restriction" sounds better when talking about an "area of service", which the bootserver school restrictions are. :)

Also some minor corrections for Finnish.

I hope I didn't miss anything I would need to change/update besides these (e.g. tests?).